### PR TITLE
Add shared default splitting options

### DIFF
--- a/prisma/migrations/20250607182543_add_group_default_splitting_options/migration.sql
+++ b/prisma/migrations/20250607182543_add_group_default_splitting_options/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Group" ADD COLUMN "defaultSplittingOptions" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,6 +16,7 @@ model Group {
   name         String
   information  String?       @db.Text
   currency     String        @default("$")
+  defaultSplittingOptions Json?
   participants Participant[]
   expenses     Expense[]
   activities   Activity[]

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -318,6 +318,18 @@ export async function updateGroup(
   })
 }
 
+export async function setGroupDefaultSplittingOptions(
+  groupId: string,
+  splittingOptions: SplittingOptions,
+) {
+  await prisma.group.update({
+    where: { id: groupId },
+    data: {
+      defaultSplittingOptions: splittingOptions,
+    },
+  })
+}
+
 export async function getGroup(groupId: string) {
   return prisma.group.findUnique({
     where: { id: groupId },

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -155,8 +155,18 @@ export const expenseFormSchema = z
 
 export type ExpenseFormValues = z.infer<typeof expenseFormSchema>
 
-export type SplittingOptions = {
-  // Used for saving default splitting options in localStorage
-  splitMode: SplitMode
-  paidFor: ExpenseFormValues['paidFor'] | null
-}
+export const splittingOptionsSchema = z.object({
+  splitMode: z.enum<SplitMode, [SplitMode, ...SplitMode[]]>(
+    Object.values(SplitMode) as any,
+  ),
+  paidFor: z
+    .array(
+      z.object({
+        participant: z.string(),
+        shares: z.number().int(),
+      }),
+    )
+    .nullable(),
+})
+
+export type SplittingOptions = z.infer<typeof splittingOptionsSchema>

--- a/src/trpc/routers/groups/index.ts
+++ b/src/trpc/routers/groups/index.ts
@@ -2,6 +2,7 @@ import { createTRPCRouter } from '@/trpc/init'
 import { activitiesRouter } from '@/trpc/routers/groups/activities'
 import { groupBalancesRouter } from '@/trpc/routers/groups/balances'
 import { createGroupProcedure } from '@/trpc/routers/groups/create.procedure'
+import { setDefaultSplittingOptionsProcedure } from '@/trpc/routers/groups/setDefaultSplittingOptions.procedure'
 import { groupExpensesRouter } from '@/trpc/routers/groups/expenses'
 import { getGroupProcedure } from '@/trpc/routers/groups/get.procedure'
 import { groupStatsRouter } from '@/trpc/routers/groups/stats'
@@ -20,4 +21,5 @@ export const groupsRouter = createTRPCRouter({
   list: listGroupsProcedure,
   create: createGroupProcedure,
   update: updateGroupProcedure,
+  setDefaultSplittingOptions: setDefaultSplittingOptionsProcedure,
 })

--- a/src/trpc/routers/groups/setDefaultSplittingOptions.procedure.ts
+++ b/src/trpc/routers/groups/setDefaultSplittingOptions.procedure.ts
@@ -1,0 +1,15 @@
+import { setGroupDefaultSplittingOptions } from '@/lib/api'
+import { splittingOptionsSchema } from '@/lib/schemas'
+import { baseProcedure } from '@/trpc/init'
+import { z } from 'zod'
+
+export const setDefaultSplittingOptionsProcedure = baseProcedure
+  .input(
+    z.object({
+      groupId: z.string().min(1),
+      splittingOptions: splittingOptionsSchema,
+    }),
+  )
+  .mutation(async ({ input: { groupId, splittingOptions } }) => {
+    await setGroupDefaultSplittingOptions(groupId, splittingOptions)
+  })


### PR DESCRIPTION
## Summary
- allow defining default splitting options for a group
- expose TRPC endpoint to update group defaults
- persist defaults to DB and send them to clients
- update expense form to use and save shared defaults
- add DB migration for the new field

## Testing
- `npx prisma generate` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844838b60b48331810ed6b3dedb8858