### PR TITLE
Add default splitting settings

### DIFF
--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -101,7 +101,13 @@
       "add": "Mitglied hinzufügen",
       "John": "Johannes",
       "Jane": "Janina",
-      "Jack": "Jakob"
+    "Jack": "Jakob"
+    },
+    "DefaultSplitting": {
+      "title": "Standardaufteilung",
+      "description": "Lege einen Standardfaktor pro Mitglied fest. Dieser wird für neue Ausgaben übernommen.",
+      "factorLabel": "Faktor",
+      "reset": "Faktoren zurücksetzen"
     },
     "Settings": {
       "title": "Lokale Einstellungen",

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -102,7 +102,13 @@
       "add": "Add participant",
       "John": "John",
       "Jane": "Jane",
-      "Jack": "Jack"
+    "Jack": "Jack"
+    },
+    "DefaultSplitting": {
+      "title": "Default splitting",
+      "description": "Set a default factor for each participant. This will pre-fill new expenses.",
+      "factorLabel": "Factor",
+      "reset": "Reset factors"
     },
     "Settings": {
       "title": "Local settings",

--- a/src/app/groups/[groupId]/edit/default-splitting-form.tsx
+++ b/src/app/groups/[groupId]/edit/default-splitting-form.tsx
@@ -1,0 +1,114 @@
+'use client'
+
+import { SubmitButton } from '@/components/submit-button'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+import { SplittingOptions, splittingOptionsSchema } from '@/lib/schemas'
+import { trpc } from '@/trpc/client'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useTranslations } from 'next-intl'
+import { useForm } from 'react-hook-form'
+import type { getGroup } from '@/lib/api'
+
+export function DefaultSplittingForm({
+  group,
+}: {
+  group: NonNullable<Awaited<ReturnType<typeof getGroup>>>
+}) {
+  const t = useTranslations('GroupForm')
+  const tDefault = useTranslations('GroupForm.DefaultSplitting')
+  const { mutateAsync } = trpc.groups.setDefaultSplittingOptions.useMutation()
+  const utils = trpc.useUtils()
+
+  const defaultValues: SplittingOptions = {
+    splitMode: 'BY_SHARES',
+    paidFor: group.participants.map((p) => {
+      const existing =
+        (group.defaultSplittingOptions as SplittingOptions | null)?.paidFor?.find(
+          (pf) => pf.participant === p.id,
+        )
+      return { participant: p.id, shares: existing ? existing.shares : 1 }
+    }),
+  }
+
+  const form = useForm<SplittingOptions>({
+    resolver: zodResolver(splittingOptionsSchema),
+    defaultValues,
+  })
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(async (values) => {
+          await mutateAsync({ groupId: group.id, splittingOptions: values })
+          await utils.groups.invalidate()
+        })}
+      >
+        <Card className="mb-4">
+          <CardHeader>
+            <CardTitle>{tDefault('title')}</CardTitle>
+            <CardDescription>{tDefault('description')}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ul className="flex flex-col gap-2">
+              {group.participants.map((participant, index) => (
+                <li key={participant.id} className="flex items-center gap-2">
+                  <FormLabel className="flex-1">
+                    {participant.name}
+                  </FormLabel>
+                  <FormField
+                    control={form.control}
+                    name={`paidFor.${index}.shares` as const}
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormControl>
+                          <Input
+                            type="number"
+                            className="w-24"
+                            placeholder={tDefault('factorLabel')}
+                            {...field}
+                            onChange={(e) =>
+                              field.onChange(Number(e.target.value))
+                            }
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <input
+                    type="hidden"
+                    {...form.register(`paidFor.${index}.participant`)}
+                    value={participant.id}
+                  />
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+          <CardFooter className="flex gap-2">
+            <Button
+              variant="secondary"
+              type="button"
+              onClick={() =>
+                form.setValue(
+                  'paidFor',
+                  form.getValues().paidFor?.map((pf) => ({
+                    ...pf,
+                    shares: 1,
+                  })) ?? null,
+                )
+              }
+            >
+              {tDefault('reset')}
+            </Button>
+            <SubmitButton loadingContent={t('Settings.saving')}>
+              {t('Settings.save')}
+            </SubmitButton>
+          </CardFooter>
+        </Card>
+      </form>
+    </Form>
+  )
+}

--- a/src/app/groups/[groupId]/edit/edit-group.tsx
+++ b/src/app/groups/[groupId]/edit/edit-group.tsx
@@ -3,6 +3,7 @@
 import { GroupForm } from '@/components/group-form'
 import { trpc } from '@/trpc/client'
 import { useCurrentGroup } from '../current-group-context'
+import { DefaultSplittingForm } from './default-splitting-form'
 
 export const EditGroup = () => {
   const { groupId } = useCurrentGroup()
@@ -13,13 +14,16 @@ export const EditGroup = () => {
   if (isLoading) return <></>
 
   return (
-    <GroupForm
-      group={data?.group}
-      onSubmit={async (groupFormValues, participantId) => {
-        await mutateAsync({ groupId, participantId, groupFormValues })
-        await utils.groups.invalidate()
-      }}
-      protectedParticipantIds={data?.participantsWithExpenses}
-    />
+    <>
+      <GroupForm
+        group={data?.group}
+        onSubmit={async (groupFormValues, participantId) => {
+          await mutateAsync({ groupId, participantId, groupFormValues })
+          await utils.groups.invalidate()
+        }}
+        protectedParticipantIds={data?.participantsWithExpenses}
+      />
+      {data?.group && <DefaultSplittingForm group={data.group} />}
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- allow editing of default splitting factors in group settings
- translate default splitting UI in en-US and de-DE
- reset factors to 1 and fix translation scope

## Testing
- `npm run check-formatting` *(fails: Cannot find package 'prettier-plugin-organize-imports')*
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails due to missing dependencies)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68494cc704208331bd6a973b7589775e