### PR TITLE
Fix missing SplittingOptions import

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,9 @@
 import { prisma } from '@/lib/prisma'
-import { ExpenseFormValues, GroupFormValues } from '@/lib/schemas'
+import {
+  ExpenseFormValues,
+  GroupFormValues,
+  SplittingOptions,
+} from '@/lib/schemas'
 import {
   ActivityType,
   Expense,


### PR DESCRIPTION
## Summary
- import SplittingOptions type in api helpers

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68496789a0a48331b5ff2256f4a33217