### PR TITLE
Fix default splitting fetch

### DIFF
--- a/src/app/groups/create/create-group.tsx
+++ b/src/app/groups/create/create-group.tsx
@@ -31,7 +31,7 @@ export const CreateGroup = () => {
           const { groupId } = await mutateAsync({ groupFormValues })
           await utils.groups.invalidate()
           if (defaultOptions) {
-            const details = await trpc.groups.getDetails.fetch({ groupId })
+            const details = await utils.groups.getDetails.fetch({ groupId })
             await setDefaultSplitting({
               groupId,
               splittingOptions: {


### PR DESCRIPTION
## Summary
- use `utils` from `trpc.useUtils` when fetching group details after creation

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e231bff9c8331ada76a7f43d34057