### PR TITLE
Fix default splitting form usage

### DIFF
--- a/src/app/groups/create/create-group.tsx
+++ b/src/app/groups/create/create-group.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { GroupForm } from '@/components/group-form'
-import { DefaultSplittingForm } from '@/app/groups/[groupId]/edit/default-splitting-form'
+import { CreateDefaultSplittingForm } from './default-splitting-form'
 import { SplittingOptions } from '@/lib/schemas'
 import { trpc } from '@/trpc/client'
 import { useRouter } from 'next/navigation'
@@ -31,7 +31,7 @@ export const CreateGroup = () => {
           const { groupId } = await mutateAsync({ groupFormValues })
           await utils.groups.invalidate()
           if (defaultOptions) {
-            const details = await trpc.groups.getDetails.fetch({ groupId })
+            const details = await utils.groups.getDetails.fetch({ groupId })
             await setDefaultSplitting({
               groupId,
               splittingOptions: {
@@ -47,7 +47,7 @@ export const CreateGroup = () => {
         }}
       />
       {showDefault && (
-        <DefaultSplittingForm
+        <CreateDefaultSplittingForm
           participants={participants.map((p, i) => ({ id: String(i), name: p.name }))}
           defaultSplittingOptions={defaultOptions ?? undefined}
           onSave={async (opts) => setDefaultOptions(opts)}

--- a/src/app/groups/create/default-splitting-form.tsx
+++ b/src/app/groups/create/default-splitting-form.tsx
@@ -1,0 +1,133 @@
+'use client'
+
+import { SubmitButton } from '@/components/submit-button'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+import { SplittingOptions, splittingOptionsSchema } from '@/lib/schemas'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useTranslations } from 'next-intl'
+import { useEffect } from 'react'
+import { useForm } from 'react-hook-form'
+
+export function CreateDefaultSplittingForm({
+  participants,
+  defaultSplittingOptions,
+  onSave,
+}: {
+  participants: { id: string; name: string }[]
+  defaultSplittingOptions?: SplittingOptions | null
+  onSave: (values: SplittingOptions) => Promise<void>
+}) {
+  const t = useTranslations('GroupForm')
+  const tDefault = useTranslations('GroupForm.DefaultSplitting')
+
+  const defaultValues: SplittingOptions = {
+    splitMode: 'BY_SHARES',
+    paidFor: participants.map((p) => {
+      const existing = defaultSplittingOptions?.paidFor?.find(
+        (pf) => pf.participant === p.id,
+      )
+      return { participant: p.id, shares: existing ? existing.shares : 1 }
+    }),
+  }
+
+  const form = useForm<SplittingOptions>({
+    resolver: zodResolver(splittingOptionsSchema),
+    defaultValues,
+  })
+
+  useEffect(() => {
+    form.reset(defaultValues)
+  }, [participants, defaultSplittingOptions])
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(async (values) => {
+          await onSave(values)
+        })}
+      >
+        <Card className="mb-4">
+          <CardHeader>
+            <CardTitle>{tDefault('title')}</CardTitle>
+            <CardDescription>{tDefault('description')}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ul className="flex flex-col gap-2">
+              {participants.map((participant, index) => (
+                <li key={participant.id} className="flex items-center gap-2">
+                  <FormLabel className="flex-1">
+                    {participant.name}
+                  </FormLabel>
+                  <FormField
+                    control={form.control}
+                    name={`paidFor.${index}.shares` as const}
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormControl>
+                          <Input
+                            type="number"
+                            min={1}
+                            step={1}
+                            className="w-24"
+                            placeholder={tDefault('factorLabel')}
+                            {...field}
+                            onChange={(e) =>
+                              field.onChange(Number(e.target.value))
+                            }
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <input
+                    type="hidden"
+                    {...form.register(`paidFor.${index}.participant`)}
+                    value={participant.id}
+                  />
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+          <CardFooter className="flex gap-2">
+            <Button
+              variant="secondary"
+              type="button"
+              onClick={() =>
+                form.setValue(
+                  'paidFor',
+                  form.getValues().paidFor?.map((pf) => ({
+                    ...pf,
+                    shares: 1,
+                  })) ?? null,
+                )
+              }
+            >
+              {tDefault('reset')}
+            </Button>
+            <SubmitButton loadingContent={t('Settings.saving')}>
+              {t('Settings.save')}
+            </SubmitButton>
+          </CardFooter>
+        </Card>
+      </form>
+    </Form>
+  )
+}


### PR DESCRIPTION
## Summary
- add a dedicated default splitting form component for group creation
- update CreateGroup to use the new form and correct fetch helper

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e231bff9c8331ada76a7f43d34057