### PR TITLE
Clarify password rebuild instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,6 @@ POSTGRES_PRISMA_URL=postgresql://postgres:1234@localhost
 POSTGRES_URL_NON_POOLING=postgresql://postgres:1234@localhost
 
 NEXT_PUBLIC_DEFAULT_CURRENCY_SYMBOL=""
+
+# Uncomment to password protect your local instance
+# SHARED_PASSWORD=my-secret

--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ If you want to contribute financially and help us keep the application free and 
 1. Clone the repository (or fork it if you intend to contribute)
 2. Start a PostgreSQL server. You can run `./scripts/start-local-db.sh` if you don’t have a server already.
 3. Copy the file `.env.example` as `.env`
-4. Run `npm install` to install dependencies. This will also apply database migrations and update Prisma Client.
-5. Run `npm run dev` to start the development server
+4. Edit `.env` to override variables as needed. Set `SHARED_PASSWORD` here if you want password protection locally.
+5. Run `npm install` to install dependencies. This will also apply database migrations and update Prisma Client.
+6. Run `npm run dev` to start the development server
 
 ## Run in a container
 
@@ -103,6 +104,20 @@ You can offer users to automatically deduce the expense category from the title.
 NEXT_PUBLIC_ENABLE_CATEGORY_EXTRACT=true
 OPENAI_API_KEY=XXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ```
+
+### Password protect your instance
+
+Set the `SHARED_PASSWORD` environment variable to require a password before the
+application can be used. Users will be redirected to `/login` and, upon
+success, an HTTP-only cookie keeps them logged in. If this variable is not set,
+the application behaves as usual without any password prompt.
+
+Locally, define `SHARED_PASSWORD` in your `.env` file **before** running `npm run dev`
+or `npm run build`. Environment variables are read during the build, so if you change the
+password later you must rebuild (or restart the dev server) for it to take effect. During
+the build you will see a log message confirming whether password protection is enabled.
+
+On Vercel you can define this variable from the **Project > Settings > Environment Variables** page.
 
 ## License
 

--- a/container.env.example
+++ b/container.env.example
@@ -4,3 +4,6 @@ POSTGRES_PASSWORD=1234
 # app
 POSTGRES_PRISMA_URL=postgresql://postgres:${POSTGRES_PASSWORD}@db
 POSTGRES_URL_NON_POOLING=postgresql://postgres:${POSTGRES_PASSWORD}@db
+
+# Uncomment to password protect your container
+# SHARED_PASSWORD=my-secret

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+export function middleware(request: NextRequest) {
+  const password = process.env.SHARED_PASSWORD
+  if (!password) {
+    return NextResponse.next()
+  }
+
+  const { pathname } = request.nextUrl
+  if (
+    pathname.startsWith('/_next') ||
+    pathname.startsWith('/favicon') ||
+    pathname.startsWith('/apple-icon') ||
+    pathname.startsWith('/android-chrome')
+  ) {
+    return NextResponse.next()
+  }
+
+  if (pathname === '/login' || pathname === '/api/login') {
+    return NextResponse.next()
+  }
+
+  const cookie = request.cookies.get('spliit-auth')
+  if (cookie && cookie.value === password) {
+    return NextResponse.next()
+  }
+
+  const loginUrl = request.nextUrl.clone()
+  loginUrl.pathname = '/login'
+  return NextResponse.redirect(loginUrl)
+}
+
+export const config = {
+  matcher: '/:path*',
+}

--- a/src/app/api/login/route.ts
+++ b/src/app/api/login/route.ts
@@ -1,0 +1,22 @@
+import { env } from '@/lib/env'
+import { NextResponse } from 'next/server'
+
+export async function POST(request: Request) {
+  if (!env.SHARED_PASSWORD) {
+    return NextResponse.json({ success: true })
+  }
+
+  const { password } = (await request.json()) as { password?: string }
+  if (password === env.SHARED_PASSWORD) {
+    const response = NextResponse.json({ success: true })
+    response.cookies.set('spliit-auth', password, {
+      httpOnly: true,
+      sameSite: 'strict',
+      secure: process.env.NODE_ENV === 'production',
+      maxAge: 60 * 60 * 24 * 30,
+      path: '/',
+    })
+    return response
+  }
+  return NextResponse.json({ success: false }, { status: 401 })
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,37 @@
+'use client'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { useRouter } from 'next/navigation'
+import { FormEvent, useState } from 'react'
+
+export default function LoginPage() {
+  const router = useRouter()
+  const [error, setError] = useState('')
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    const formData = new FormData(e.currentTarget)
+    const password = formData.get('password') as string
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password }),
+    })
+    if (res.ok) {
+      router.push('/')
+      router.refresh()
+    } else {
+      setError('Wrong password')
+    }
+  }
+
+  return (
+    <main className="min-h-screen flex items-center justify-center p-4">
+      <form onSubmit={handleSubmit} className="space-y-4 max-w-sm w-full">
+        <Input type="password" name="password" placeholder="Password" required />
+        {error && <p className="text-destructive text-sm">{error}</p>}
+        <Button type="submit" className="w-full">Enter</Button>
+      </form>
+    </main>
+  )
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -36,6 +36,7 @@ const envSchema = z
       z.boolean().default(false),
     ),
     OPENAI_API_KEY: z.string().optional(),
+    SHARED_PASSWORD: z.string().optional(),
   })
   .superRefine((env, ctx) => {
     if (
@@ -66,3 +67,9 @@ const envSchema = z
   })
 
 export const env = envSchema.parse(process.env)
+
+if (env.SHARED_PASSWORD) {
+  console.log('Password protection enabled during build')
+} else {
+  console.log('No password set; app will run without protection')
+}


### PR DESCRIPTION
## Summary
- note that SHARED_PASSWORD must be set before dev or build and rebuild when it changes
- add newline at end of `.env.example`
- display debug log whether password protection is enabled during build

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*


------
https://chatgpt.com/codex/tasks/task_e_685a8f9183cc8331bd77e09ca42b34fe